### PR TITLE
build: Remove unused http-factory-guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "http-interop/http-factory-guzzle": "^0.1.0",
         "illuminate/support": "^12.1",
         "openai-php/client": "^0.10.3",
         "ramsey/uuid": "^4.7"


### PR DESCRIPTION
Dependency to http-factory-guzzle is unused and should be removed
#10 