### PR TITLE
feat: Add support for the new Streamable Http Transporter for MCP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "laravel/prompts": "^0.3.5",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.0 || ^12.0",
-        "swisnl/mcp-client": "^0.1.0",
+        "swisnl/mcp-client": "^0.2.1",
         "swisnl/php-http-fixture-client": "^3.1",
         "symfony/console": "^7.2",
         "vlucas/phpdotenv": "^5.6"

--- a/src/Mcp/McpConnection.php
+++ b/src/Mcp/McpConnection.php
@@ -58,6 +58,22 @@ class McpConnection implements McpConnectionInterface
     }
 
     /**
+     * Create a new MCP connection for a given Streamable HTTP endpoint
+     *
+     * @param string $endpoint
+     * @return self
+     */
+    public static function forStreamableHttp(string $endpoint): self
+    {
+        $client = Client::withStreamableHttp($endpoint);
+
+        $connection = new self($client, 'MCP server');
+        $connection->withCacheKey('mcp_tools_' . md5($endpoint));
+
+        return $connection;
+    }
+
+    /**
      * Create a new MCP connection for a given SSE endpoint
      *
      * @param string $endpoint

--- a/tests/Unit/Mcp/McpConnectionTest.php
+++ b/tests/Unit/Mcp/McpConnectionTest.php
@@ -318,6 +318,22 @@ class McpConnectionTest extends TestCase
     }
 
     /**
+     * Test creating an MCP connection for a Streamable HTTP endpoint
+     */
+    public function testForStreamableHttp(): void
+    {
+        $endpoint = 'https://example.com/events';
+
+        // Create a connection using the static method
+        $connection = McpConnection::forStreamableHttp($endpoint);
+
+        // Verify the connection was created correctly
+        $this->assertInstanceOf(McpConnection::class, $connection);
+        $this->assertEquals('MCP server', $connection->getName());
+        $this->assertEquals('mcp_tools_' . md5($endpoint), $this->getPrivateProperty($connection, 'cacheKey'));
+    }
+
+    /**
      * Test creating an MCP connection for an SSE endpoint
      */
     public function testForSse(): void


### PR DESCRIPTION
MCP version 2025-03-26 added a new Streamable Http transporter that works mostly the same as the SSE transporter only with direct responses and sessions.

This PR adds support for the Streamable Http transporter