### PR TITLE
Feat: Add support for observing reasoning tokens

### DIFF
--- a/src/AgentObserver.php
+++ b/src/AgentObserver.php
@@ -2,6 +2,7 @@
 
 namespace Swis\Agents;
 
+use OpenAI\Responses\Responses\CreateStreamedResponse;
 use Swis\Agents\Interfaces\AgentInterface;
 use Swis\Agents\Interfaces\MessageInterface;
 use Swis\Agents\Orchestrator\RunContext;
@@ -39,6 +40,43 @@ abstract class AgentObserver
      * @return void
      */
     public function onResponseInterval(AgentInterface $agent, Payload $payload, RunContext $context): void
+    {
+    }
+
+    /**
+     * Called when an agent generates a complete reasoning message
+     *
+     * @param AgentInterface $agent The agent that generated the response
+     * @param MessageInterface $message The complete reasoning message that was generated
+     * @param RunContext $context The execution context
+     * @return void
+     */
+    public function onReasoning(AgentInterface $agent, MessageInterface $message, RunContext $context): void
+    {
+    }
+
+    /**
+     * Called during streaming when a partial reasoning token is received
+     *
+     * @param AgentInterface $agent The agent that generated the response token
+     * @param Payload $payload The reasoning payload
+     * @param RunContext $context The execution context
+     * @return void
+     */
+    public function onReasoningInterval(AgentInterface $agent, Payload $payload, RunContext $context): void
+    {
+    }
+
+    /**
+     * Called during streaming when an SSE event is received
+     *
+     * @param RunContext $context The run context
+     * @param AgentInterface $agent The agent that generated the reasoning token
+     * @param string $event The name of the event
+     * @param CreateStreamedResponse $response The response belonging to the event
+     * @return void
+     */
+    public function onStreamEvent(AgentInterface $agent, string $event, CreateStreamedResponse $response, RunContext $context): void
     {
     }
 

--- a/src/Orchestrator/ObserverInvoker.php
+++ b/src/Orchestrator/ObserverInvoker.php
@@ -2,6 +2,7 @@
 
 namespace Swis\Agents\Orchestrator;
 
+use OpenAI\Responses\Responses\CreateStreamedResponse;
 use Swis\Agents\Interfaces\AgentInterface;
 use Swis\Agents\Interfaces\MessageInterface;
 use Swis\Agents\Response\Payload;
@@ -45,6 +46,52 @@ class ObserverInvoker
     {
         foreach ($context->agentObservers() as $observer) {
             $observer->onResponseInterval($agent, $payload, $context);
+        }
+    }
+
+    /**
+     * Notify all agent observers about a reasoning message
+     *
+     * @param RunContext $context The run context
+     * @param AgentInterface $agent The agent that generated the reasoning
+     * @param MessageInterface $message The reasoning message that was generated
+     * @return void
+     */
+    public function agentOnReasoning(RunContext $context, AgentInterface $agent, MessageInterface $message): void
+    {
+        foreach ($context->agentObservers() as $observer) {
+            $observer->onReasoning($agent, $message, $context);
+        }
+    }
+
+    /**
+     * Notify all agent observers about an intermediate reasoning token during streaming
+     *
+     * @param RunContext $context The run context
+     * @param AgentInterface $agent The agent that generated the reasoning token
+     * @param Payload $payload The reasoning token payload
+     * @return void
+     */
+    public function agentOnReasoningInterval(RunContext $context, AgentInterface $agent, Payload $payload): void
+    {
+        foreach ($context->agentObservers() as $observer) {
+            $observer->onReasoningInterval($agent, $payload, $context);
+        }
+    }
+
+    /**
+     * Notify all agent observers about an SSE event
+     *
+     * @param RunContext $context The run context
+     * @param AgentInterface $agent The agent that generated the reasoning token
+     * @param string $event The name of the event
+     * @param CreateStreamedResponse $response The response belonging to the event
+     * @return void
+     */
+    public function agentOnStreamEvent(RunContext $context, AgentInterface $agent, string $event, CreateStreamedResponse $response): void
+    {
+        foreach ($context->agentObservers() as $observer) {
+            $observer->onStreamEvent($agent, $event, $response, $context);
         }
     }
 


### PR DESCRIPTION
This PR adds three new `AgentObserver` methods

- `onReasoning`: Called when reasoning is done
- `onReasoningInterval`: Called on each received reasoning token
- `onStreamEvent`: Called on each SSE event