### PR TITLE
Add MCP tool alias support for agent-visible names and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ $mcpConnection = McpConnection::forSse('http://localhost:3000');
 // Optionally restrict which tools are available
 $mcpConnection->withTools('calculator', 'weather');
 
+// Optionally expose MCP tools under alternate names for the agent
+$mcpConnection->withAlternateToolNames([
+    'get_current_weather' => 'weather',
+]);
+
+// Optionally expose MCP tools with alternate descriptions for the agent
+$mcpConnection->withAlternateToolDescriptions([
+    'get_current_weather' => 'Get current weather conditions by location.',
+]);
+
 // Create an agent with the MCP connection
 $agent = new Agent(
     name: 'Assistant with MCP Tools',

--- a/src/Interfaces/McpConnectionInterface.php
+++ b/src/Interfaces/McpConnectionInterface.php
@@ -36,6 +36,28 @@ interface McpConnectionInterface
     public function withTools(string ...$toolNames): self;
 
     /**
+     * Define alternate names for MCP tools.
+     *
+     * The array should map original MCP tool names to the names exposed
+     * to the agent.
+     *
+     * @param array<string, string> $alternateToolNames
+     * @return self
+     */
+    public function withAlternateToolNames(array $alternateToolNames): self;
+
+    /**
+     * Define alternate descriptions for MCP tools.
+     *
+     * The array should map original MCP tool names to the descriptions
+     * exposed to the agent.
+     *
+     * @param array<string, string> $alternateToolDescriptions
+     * @return self
+     */
+    public function withAlternateToolDescriptions(array $alternateToolDescriptions): self;
+
+    /**
      * List all tools available from this MCP connection
      *
      * @param bool $refresh Whether to refresh the cached tools

--- a/src/Mcp/McpTool.php
+++ b/src/Mcp/McpTool.php
@@ -22,12 +22,17 @@ class McpTool extends DynamicTool
      */
     public function __construct(
         protected McpConnection $connection,
-        protected McpToolDefinition $mcpToolDefinition
+        protected McpToolDefinition $mcpToolDefinition,
+        ?string $name = null,
+        ?string $description = null
     ) {
+        $toolName = $name ?? $mcpToolDefinition->getName();
+        $toolDescription = $description ?? $mcpToolDefinition->getDescription() ?? "MCP Tool: {$toolName}";
+
         // Initialize the tool with name and description from MCP
         parent::__construct(
-            $mcpToolDefinition->getName(),
-            $mcpToolDefinition->getDescription() ?? "MCP Tool: {$mcpToolDefinition->getName()}"
+            $toolName,
+            $toolDescription
         );
 
         // Register dynamic properties based on the MCP tool schema
@@ -42,6 +47,16 @@ class McpTool extends DynamicTool
     public function mcpDefinition(): McpToolDefinition
     {
         return $this->mcpToolDefinition;
+    }
+
+    /**
+     * Get the original MCP tool name.
+     *
+     * @return string
+     */
+    public function mcpName(): string
+    {
+        return $this->mcpToolDefinition->getName();
     }
 
     /**

--- a/src/Mcp/McpToolFactory.php
+++ b/src/Mcp/McpToolFactory.php
@@ -17,11 +17,17 @@ class McpToolFactory
      *
      * @param McpConnection $connection The MCP connection
      * @param McpToolDefinition $mcpToolDefinition The MCP tool definitions
+     * @param string|null $toolName The tool name exposed to the agent
+     * @param string|null $toolDescription The tool description exposed to the agent
      * @return McpTool The wrapped MCP tool
      */
-    public static function createTool(McpConnection $connection, McpToolDefinition $mcpToolDefinition): McpTool
-    {
-        return new McpTool($connection, $mcpToolDefinition);
+    public static function createTool(
+        McpConnection $connection,
+        McpToolDefinition $mcpToolDefinition,
+        ?string $toolName = null,
+        ?string $toolDescription = null
+    ): McpTool {
+        return new McpTool($connection, $mcpToolDefinition, $toolName, $toolDescription);
     }
 
     /**
@@ -29,13 +35,22 @@ class McpToolFactory
      *
      * @param McpConnection $connection The MCP connection
      * @param array<McpToolDefinition> $mcpToolDefinitions The MCP tool definitions
+     * @param array<string, string> $alternateToolNames Map of MCP tool names => agent-visible tool names
+     * @param array<string, string> $alternateToolDescriptions Map of MCP tool names => agent-visible tool descriptions
      * @return array<string, McpTool> Array of MCP tools
      */
-    public static function createTools(McpConnection $connection, array $mcpToolDefinitions): array
-    {
+    public static function createTools(
+        McpConnection $connection,
+        array $mcpToolDefinitions,
+        array $alternateToolNames = [],
+        array $alternateToolDescriptions = []
+    ): array {
         $tools = [];
         foreach ($mcpToolDefinitions as $mcpToolDefinition) {
-            $tool = self::createTool($connection, $mcpToolDefinition);
+            $mcpToolName = $mcpToolDefinition->getName();
+            $toolName = $alternateToolNames[$mcpToolName] ?? null;
+            $toolDescription = $alternateToolDescriptions[$mcpToolName] ?? null;
+            $tool = self::createTool($connection, $mcpToolDefinition, $toolName, $toolDescription);
             $tools[$tool->name()] = $tool;
         }
 

--- a/tests/Unit/Mcp/McpToolFactoryTest.php
+++ b/tests/Unit/Mcp/McpToolFactoryTest.php
@@ -86,4 +86,52 @@ class McpToolFactoryTest extends TestCase
         $this->assertIsArray($tools);
         $this->assertEmpty($tools);
     }
+
+    /**
+     * Test creating tools with alternate names
+     */
+    public function testCreateToolsWithAlternateNames(): void
+    {
+        $connection = $this->createMock(McpConnection::class);
+        $mcpToolDefinition = $this->createMock(McpToolDefinition::class);
+
+        $mcpToolDefinition->method('getName')->willReturn('real-tool-name');
+        $mcpToolDefinition->method('getDescription')->willReturn('Real tool description');
+        $mcpToolDefinition->method('getSchema')->willReturn([]);
+
+        $tools = McpToolFactory::createTools(
+            $connection,
+            [$mcpToolDefinition],
+            ['real-tool-name' => 'alias-tool-name']
+        );
+
+        $this->assertCount(1, $tools);
+        $this->assertArrayHasKey('alias-tool-name', $tools);
+        $this->assertEquals('alias-tool-name', $tools['alias-tool-name']->name());
+        $this->assertEquals('real-tool-name', $tools['alias-tool-name']->mcpName());
+    }
+
+    /**
+     * Test creating tools with alternate descriptions
+     */
+    public function testCreateToolsWithAlternateDescriptions(): void
+    {
+        $connection = $this->createMock(McpConnection::class);
+        $mcpToolDefinition = $this->createMock(McpToolDefinition::class);
+
+        $mcpToolDefinition->method('getName')->willReturn('real-tool-name');
+        $mcpToolDefinition->method('getDescription')->willReturn('Original description');
+        $mcpToolDefinition->method('getSchema')->willReturn([]);
+
+        $tools = McpToolFactory::createTools(
+            $connection,
+            [$mcpToolDefinition],
+            [],
+            ['real-tool-name' => 'Agent-visible description']
+        );
+
+        $this->assertCount(1, $tools);
+        $this->assertArrayHasKey('real-tool-name', $tools);
+        $this->assertEquals('Agent-visible description', $tools['real-tool-name']->description());
+    }
 }

--- a/tests/Unit/Mcp/McpToolTest.php
+++ b/tests/Unit/Mcp/McpToolTest.php
@@ -29,9 +29,45 @@ class McpToolTest extends TestCase
 
         // Test basic properties
         $this->assertEquals('test-tool', $tool->name());
+        $this->assertEquals('test-tool', $tool->mcpName());
         $this->assertEquals('Test tool description', $tool->description());
         $this->assertSame($connection, $tool->connection());
         $this->assertSame($mcpToolDefinition, $tool->mcpDefinition());
+    }
+
+    /**
+     * Test alternate tool names keep original MCP name
+     */
+    public function testAlternateToolName(): void
+    {
+        $connection = $this->createMock(McpConnection::class);
+        $mcpToolDefinition = $this->createMock(McpToolDefinition::class);
+
+        $mcpToolDefinition->method('getName')->willReturn('real-tool-name');
+        $mcpToolDefinition->method('getDescription')->willReturn('Test tool description');
+        $mcpToolDefinition->method('getSchema')->willReturn([]);
+
+        $tool = new McpTool($connection, $mcpToolDefinition, 'alias-tool-name');
+
+        $this->assertEquals('alias-tool-name', $tool->name());
+        $this->assertEquals('real-tool-name', $tool->mcpName());
+    }
+
+    /**
+     * Test alternate description is exposed to the agent
+     */
+    public function testAlternateToolDescription(): void
+    {
+        $connection = $this->createMock(McpConnection::class);
+        $mcpToolDefinition = $this->createMock(McpToolDefinition::class);
+
+        $mcpToolDefinition->method('getName')->willReturn('real-tool-name');
+        $mcpToolDefinition->method('getDescription')->willReturn('Original description');
+        $mcpToolDefinition->method('getSchema')->willReturn([]);
+
+        $tool = new McpTool($connection, $mcpToolDefinition, null, 'Agent-visible description');
+
+        $this->assertEquals('Agent-visible description', $tool->description());
     }
 
     /**


### PR DESCRIPTION
### Why

Agents may need cleaner or domain-specific tool naming/wording without requiring MCP server-side tool renames. Also, there could be conflicts in tool names when using multiple MCP servers. This keeps agent UX flexible while maintaining protocol correctness.

### Summary

This PR adds support for exposing MCP tools to the agent under alternate names and descriptions, while preserving calls to the original MCP tool names.

**What changed**

- Added `McpConnection::withAlternateToolNames(array $map)`
  - Map format: `['mcp_tool_name' => 'agent_visible_name']`
- Added `McpConnection::withAlternateToolDescriptions(array $map)`
  - Map format: `['mcp_tool_name' => 'agent_visible_description']`
- Updated MCP tool construction to support:
  - agent-visible tool name override
  - agent-visible tool description override
- Updated README usage examples for both name and description overrides.